### PR TITLE
Bump dependencies to bookworm version

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,7 +1,7 @@
 # This Dockerfile tests the hack/Makefile output against git2go.
 ARG BASE_VARIANT=bullseye
-ARG GO_VERSION=1.17.5
-ARG XX_VERSION=1.0.0-rc.2
+ARG GO_VERSION=1.17.6
+ARG XX_VERSION=1.1.0
 
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx
 
@@ -12,6 +12,14 @@ FROM gostable AS go-linux
 FROM go-${TARGETOS} AS build-base-bullseye
 
 COPY --from=xx / /
+
+# Align golang base image with bookworm. 
+# TODO: Replace this with a golang bookworm variant, once it is released.
+RUN echo "deb http://deb.debian.org/debian bookworm main" > /etc/apt/sources.list.d/bookworm.list \
+	&& echo "deb-src http://deb.debian.org/debian bookworm main" /etc/apt/sources.list.d/bookworm.list \
+	&& xx-apt update \
+	&& xx-apt -t bookworm upgrade -y
+
 COPY ./hack/Makefile /libgit2/Makefile
 
 RUN make -C /libgit2/ cmake

--- a/README.md
+++ b/README.md
@@ -54,12 +54,12 @@ The following dependencies should be present in the image running the applicatio
 
 - `libc6`
 - `ca-certificates`
-- `zlib1g/sid`
-- `libssl1.1/sid`
-- `libssh2-1/sid`
+- `zlib1g/bookworm`
+- `libssl1.1/bookworm`
+- `libssh2-1/bookworm`
 
-**Note:** at present, all dependencies suffixed with `sid` should be installed from Debian's `sid` (unstable) release,
-[due to a misconfiguration in `libssh2-1` for earlier versions][libssh2-1-misconfiguration].
+**Note:** at present, all dependencies suffixed with `bookworm` must be installed from Debian's `bookworm` release,
+[due to a misconfiguration in `libssh2-1` in earlier versions][libssh2-1-misconfiguration].
 
 ### `Dockerfile` example
 
@@ -67,7 +67,7 @@ The following dependencies should be present in the image running the applicatio
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx
 FROM fluxcd/golang-with-libgit2 as libgit2
 
-FROM --platform=$BUILDPLATFORM golang:1.16.8-bullseye as build
+FROM --platform=$BUILDPLATFORM golang:1.17.6-bullseye as build
 
 # Copy the build utiltiies
 COPY --from=xx / /
@@ -103,14 +103,12 @@ ARG TARGETPLATFORM
 RUN xx-go build -o app \
     main.go
 
-FROM debian:buster-slim as controller
+FROM debian:bookworm-slim as controller
 
 # Install runtime dependencies
-RUN echo "deb http://deb.debian.org/debian sid main" >> /etc/apt/sources.list \
-    && echo "deb-src http://deb.debian.org/debian sid main" >> /etc/apt/sources.list \
-    && apt update \
-    && apt install --no-install-recommends -y zlib1g/sid libssl1.1/sid libssh2-1/sid \
-    && apt install --no-install-recommends -y ca-certificates \
+RUN apt update \
+    && apt install -y zlib1g/bookworm libssl1.1 libssh2-1 \
+    && apt install -y ca-certificates \
     && apt clean \
     && apt autoremove --purge -y \
     && rm -rf /var/lib/apt/lists/*

--- a/hack/Makefile
+++ b/hack/Makefile
@@ -47,20 +47,20 @@ endif
 cmake:
 ifeq (debian,$(XX_VENDOR))
 cmake:
-	apt-get update && apt-get install --no-install-recommends -y clang cmake
+	apt-get update && apt-get install -y clang cmake
 endif
 .PHONY: cmake
 
 base:
 ifeq (debian,$(XX_VENDOR))
 base:
-	xx-apt update && xx-apt install --no-install-recommends -y binutils gcc libc6-dev dpkg-dev
+	xx-apt update && xx-apt install -y binutils gcc libc6-dev dpkg-dev
 endif
 .PHONY: base
 
 dependencies: base
 ifeq (debian,$(XX_VENDOR))
-# Install libssh2 for $TARGETPLATFORM from "sid", as the version in "bullseye"
+# Install libssh2 for $TARGETPLATFORM from "bookworm", as the version in "bullseye"
 # has been linked against gcrypt, which causes issues with PKCS* formats.
 # We pull (sub)dependencies from there as well, to ensure all versions are aligned,
 # and not accidentially linked to e.g. mbedTLS (which has limited support for
@@ -80,10 +80,10 @@ endif
 dependencies:
 ifneq ("",$(DEPENDENCIES))
 	set -e; \
-	echo "deb http://deb.debian.org/debian sid main" > /etc/apt/sources.list.d/sid.list \
-	&& echo "deb-src http://deb.debian.org/debian sid main" /etc/apt/sources.list.d/sid.list \
+	echo "deb http://deb.debian.org/debian bookworm main" > /etc/apt/sources.list.d/bookworm.list \
+	&& echo "deb-src http://deb.debian.org/debian bookworm main" /etc/apt/sources.list.d/bookworm.list \
 	&& xx-apt update \
-	&& xx-apt -t sid install --no-install-recommends -y $(DEPENDENCIES)
+	&& xx-apt -t bookworm install -y $(DEPENDENCIES)
 endif
 endif
 .PHONY: dependencies


### PR DESCRIPTION
- Move on from `sid` (unstable) into `bookworm` (in testing). 
- Remove `--no-install-recommends` to ensure all chain of dependencies is correctly aligned.
- Bump XX to `1.1.0`.