### PR TITLE
Add libgit2-* as part of build targets. Revert paths-ignore changes.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,14 +4,14 @@ on:
   push:
     branches:
       - main
-      - testdarwin2
+      - libgit2-*
     tags:
       - '**'
-  #   paths-ignore:
-  #     - README.md
-  # pull_request:
-  #   paths-ignore:
-  #     - README.md
+    paths-ignore:
+      - README.md
+  pull_request:
+    paths-ignore:
+      - README.md
 
 permissions:
   contents: write # needed to write releases


### PR DESCRIPTION
- Add `libgit2-*` as target branch.
- Reverts `paths-ignore` changes from https://github.com/fluxcd/golang-with-libgit2/commit/84b717c691f41ba1046e9c30fc00d15952977fca