### PR TITLE
Update dependencies

### DIFF
--- a/hack/static.sh
+++ b/hack/static.sh
@@ -2,13 +2,13 @@
 
 set -euxo pipefail
 
-LIBGIT2_URL="${LIBGIT2_URL:-https://github.com/libgit2/libgit2/archive/refs/tags/v1.3.0.tar.gz}"
-OPENSSL_URL="${OPENSSL_URL:-https://github.com/openssl/openssl/archive/refs/tags/openssl-3.0.1.tar.gz}"
+LIBGIT2_URL="${LIBGIT2_URL:-https://github.com/libgit2/libgit2/archive/refs/tags/v1.3.1.tar.gz}"
+OPENSSL_URL="${OPENSSL_URL:-https://github.com/openssl/openssl/archive/refs/tags/openssl-3.0.2.tar.gz}"
 LIBSSH2_URL="${LIBSSH2_URL:-https://github.com/libssh2/libssh2/archive/refs/tags/libssh2-1.10.0.tar.gz}"
 
 # May be worth considering other forks/implementations that either
 # provide better performance (i.e. intel/cloudflare) or that are better maintained.
-LIBZ_URL="${LIBZ_URL:-https://github.com/madler/zlib/archive/refs/tags/v1.2.11.tar.gz}"
+LIBZ_URL="${LIBZ_URL:-https://github.com/madler/zlib/archive/refs/tags/v1.2.12.tar.gz}"
 
 TARGET_DIR="${TARGET_DIR:-/usr/local/$(xx-info triple)}"
 BUILD_ROOT_DIR="${BUILD_ROOT_DIR:-/build}"


### PR DESCRIPTION
Libgit2 to libgit2-v1.3.1:
This is a security release to provide compatibility with git's changes to address [CVE-2022-24765](https://github.com/git-for-windows/git/security/advisories/GHSA-vw2c-22j4-2fh2).
https://github.com/libgit2/libgit2/compare/v1.3.0...v1.3.1

OpenSSL to openssl-3.0.2:
Minor changes
https://github.com/openssl/openssl/compare/openssl-3.0.1...openssl-3.0.2

LIBZ to libz-v1.2.12:
Minor changes
https://github.com/madler/zlib/compare/v1.2.11...v1.2.12