### PR TITLE
Add support for libgit2-only builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -83,24 +83,37 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-ghcache-
       - run: cat ./hack/static.sh
-      - name: Build candidate image
-        id: build_candidate
+      - name: Build candidate image - libgit2 compiled with libssh2 and openssl
+        id: build_candidate_libgit2_all
         uses: docker/build-push-action@v2
         with:
           context: .
           file: Dockerfile
           platforms: ${{ env.PLATFORMS }}
           push: true
-          tags: localhost:5000/${{ github.repository_owner }}/golang-with-libgit2:latest
+          tags: localhost:5000/${{ github.repository_owner }}/golang-with-libgit2-all:latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-      - name: Inspect candidate image
+      - name: Build candidate image - libgit2 only
+        id: build_candidate_libgti2_only
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile.libgit2-only
+          platforms: ${{ env.PLATFORMS }}
+          push: true
+          tags: localhost:5000/${{ github.repository_owner }}/golang-with-libgit2-only:latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+      - name: Inspect candidate images
         run: |
-          docker buildx imagetools inspect localhost:5000/${{ github.repository_owner }}/golang-with-libgit2:latest
-      - name: Test candidate image
+          docker buildx imagetools inspect localhost:5000/${{ github.repository_owner }}/golang-with-libgit2-all:latest
+          docker buildx imagetools inspect localhost:5000/${{ github.repository_owner }}/golang-with-libgit2-only:latest
+      - name: Test candidate images
         id: test_candidate
         run: |
-          IMG=localhost:5000/${{ github.repository_owner }}/golang-with-libgit2 make test
+          IMG=localhost:5000/${{ github.repository_owner }}/golang-with-libgit2-all make test
+          IMG=localhost:5000/${{ github.repository_owner }}/golang-with-libgit2-only LIBGIT2_ONLY=true make test
       - # Temp fix
         # https://github.com/docker/build-push-action/issues/252
         # https://github.com/moby/buildkit/issues/1896
@@ -115,26 +128,52 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Compose release candidate metadata
-        id: meta
+      - name: Compose release candidate metadata - golang-with-libgit2-all
+        id: meta_libgit2_all
         uses: docker/metadata-action@v3
         if: github.event_name != 'pull_request'
         with:
           images: |
-            ghcr.io/${{ github.repository_owner }}/golang-with-libgit2
+            ghcr.io/${{ github.repository_owner }}/golang-with-libgit2-all
           tags: |
             type=schedule
             type=ref,event=branch
             type=ref,event=tag
             type=sha
             type=sha,format=long
-      - name: Release candidate image
-        id: release_candidate
+      - name: Release candidate image - golang-with-libgit2-all
+        id: release_candidate_libgit2_all
         if: github.event_name != 'pull_request'
         uses: docker/build-push-action@v2
         with:
           context: .
           file: Dockerfile
+          platforms: ${{ env.PLATFORMS }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+
+      - name: Compose release candidate metadata - golang-with-libgit2-only
+        id: meta_libgit2_only
+        uses: docker/metadata-action@v3
+        if: github.event_name != 'pull_request'
+        with:
+          images: |
+            ghcr.io/${{ github.repository_owner }}/golang-with-libgit2-only
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha
+            type=sha,format=long
+      - name: Release candidate image - golang-with-libgit2-only
+        id: release_candidate_libgit2_only
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile.libgit2-only
           platforms: ${{ env.PLATFORMS }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,20 +22,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Test build script for darwin-amd64
+      - name: Test build script for darwin-amd64 - libgit2-all
         run: |
-          TARGET_DIR=${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64 \
-          BUILD_ROOT_DIR=${GITHUB_WORKSPACE}/libgit2/build/amd \
-          ./hack/static.sh all
+          make dev-test
+          rm -rf ${GITHUB_WORKSPACE}/build rm -rf ${GITHUB_WORKSPACE}/libgit2
         env:
           MACOSX_DEPLOYMENT_TARGET: 10.15
-      - name: Test cross compile script for darwin-arm64
+      - name: Test build script for darwin-amd64 - libgit2-only
         run: |
-          TARGET_DIR=${GITHUB_WORKSPACE}/build/libgit2-darwin-arm64 \
-          BUILD_ROOT_DIR=${GITHUB_WORKSPACE}/libgit2/build/arm \
-          TARGET_ARCH=arm64 \
-          CMAKE_APPLE_SILICON_PROCESSOR=arm64 \
-          ./hack/static.sh all
+          LIBGIT2_ONLY=true make dev-test
         env:
           MACOSX_DEPLOYMENT_TARGET: 10.15
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,28 +48,52 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Build static libraries
+      - name: Build static libraries - libgit2 compiled with libssh2 and openssl
         run: |
           TARGET_DIR=${GITHUB_WORKSPACE}/build/libgit2-linux \
           BUILD_ROOT_DIR=${GITHUB_WORKSPACE}/libgit2/build/amd \
           ./hack/static.sh all
           
-          mkdir -p ./libgit2-linux/
-          mv ${GITHUB_WORKSPACE}/build/libgit2-linux/include ./libgit2-linux/
-          mv ${GITHUB_WORKSPACE}/build/libgit2-linux/share ./libgit2-linux/
-          mv ${GITHUB_WORKSPACE}/build/libgit2-linux/lib ./libgit2-linux/
-          mv ${GITHUB_WORKSPACE}/build/libgit2-linux/lib64 ./libgit2-linux/
+          mkdir -p ./libgit2-linux-libgit2-all/
+          mv ${GITHUB_WORKSPACE}/build/libgit2-linux/include ./libgit2-linux-libgit2-all/
+          mv ${GITHUB_WORKSPACE}/build/libgit2-linux/share ./libgit2-linux-libgit2-all/
+          mv ${GITHUB_WORKSPACE}/build/libgit2-linux/lib ./libgit2-linux-libgit2-all/
+          mv ${GITHUB_WORKSPACE}/build/libgit2-linux/lib64 ./libgit2-linux-libgit2-all/
 
-          tar -zcvf linux-x86_64-libs.tar.gz libgit2-linux
+          tar -zcvf linux-x86_64-libgit2-all-libs.tar.gz libgit2-linux-libgit2-all
+          rm -rf ${GITHUB_WORKSPACE}/build ${GITHUB_WORKSPACE}/libgit2
       - name: Upload Release Asset
-        id: upload-release-asset 
+        id: upload-release-asset-libgit2-all
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           upload_url: ${{ needs.github_release.outputs.release_upload_url }}
-          asset_path: ./linux-x86_64-libs.tar.gz
-          asset_name: linux-x86_64-libs.tar.gz
+          asset_path: ./linux-x86_64-libgit2-all-libs.tar.gz
+          asset_name: linux-x86_64-libgit2-all-libs.tar.gz
+          asset_content_type: application/gzip
+
+      - name: Build static libraries - libgit2 only
+        run: |
+          TARGET_DIR=${GITHUB_WORKSPACE}/build/libgit2-linux \
+          BUILD_ROOT_DIR=${GITHUB_WORKSPACE}/libgit2/build/amd \
+          ./hack/static.sh build_libgit2_only
+
+          mkdir -p ./libgit2-linux-libgit2-only/
+          mv ${GITHUB_WORKSPACE}/build/libgit2-linux/include ./libgit2-linux-libgit2-only/
+          mv ${GITHUB_WORKSPACE}/build/libgit2-linux/lib ./libgit2-linux-libgit2-only/
+
+          tar -zcvf linux-x86_64-libgit2-only-lib.tar.gz libgit2-linux-libgit2-only
+          rm -rf ${GITHUB_WORKSPACE}/build ${GITHUB_WORKSPACE}/libgit2
+      - name: Upload Release Asset
+        id: upload-release-asset-libgit2-only
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ needs.github_release.outputs.release_upload_url }}
+          asset_path: ./linux-x86_64-libgit2-only-lib.tar.gz
+          asset_name: linux-x86_64-libgit2-only-lib.tar.gz
           asset_content_type: application/gzip
 
   darwin-release:
@@ -88,7 +112,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Build universal static libraries for Darwin
+      - name: Build universal static libraries for Darwin - libgit2 compiled with libssh2 and openssl
         run: |
           TARGET_DIR=${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64 \
           BUILD_ROOT_DIR=${GITHUB_WORKSPACE}/libgit2/build/amd \
@@ -100,40 +124,80 @@ jobs:
           CMAKE_APPLE_SILICON_PROCESSOR=arm64 \
           ./hack/static.sh all
 
-          mkdir -p ./libgit2-darwin/lib
-          mv ${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64/include ./libgit2-darwin/
-          mv ${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64/share ./libgit2-darwin/
-          mv ${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64/lib/cmake ./libgit2-darwin/lib/
-          mv ${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64/lib/engines-3 ./libgit2-darwin/lib/
-          mv ${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64/lib/ossl-modules ./libgit2-darwin/lib/
-          mv ${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64/lib/pkgconfig ./libgit2-darwin/lib/
+          mkdir -p ./libgit2-darwin-libgit2-all/lib
+          mv ${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64/include ./libgit2-darwin-libgit2-all/
+          mv ${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64/share ./libgit2-darwin-libgit2-all/
+          mv ${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64/lib/cmake ./libgit2-darwin-libgt2-all/lib/
+          mv ${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64/lib/engines-3 ./libgit2-darwin-libgit2-all/lib/
+          mv ${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64/lib/ossl-modules ./libgit2-darwin-libgit2-all/lib/
+          mv ${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64/lib/pkgconfig ./libgit2-darwin-libgit2-all/lib/
 
-          libtool -static -o ./libgit2-darwin/lib/libcrypto.a \
+          libtool -static -o ./libgit2-darwin-libgit2-all/lib/libcrypto.a \
             ${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64/lib/libcrypto.a \
             ${GITHUB_WORKSPACE}/build/libgit2-darwin-arm64/lib/libcrypto.a 
-          libtool -static -o ./libgit2-darwin/lib/libgit2.a \
+
+          libtool -static -o ./libgit2-darwin-libgit2-all/lib/libgit2.a \
             ${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64/lib/libgit2.a \
             ${GITHUB_WORKSPACE}/build/libgit2-darwin-arm64/lib/libgit2.a 
-          libtool -static -o ./libgit2-darwin/lib/libssh2.a \
+
+          libtool -static -o ./libgit2-darwin-libgit2-all/lib/libssh2.a \
             ${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64/lib/libssh2.a \
             ${GITHUB_WORKSPACE}/build/libgit2-darwin-arm64/lib/libssh2.a 
-          libtool -static -o ./libgit2-darwin/lib/libssl.a \
+
+          libtool -static -o ./libgit2-darwin-libgit2-all/lib/libssl.a \
             ${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64/lib/libssl.a \
             ${GITHUB_WORKSPACE}/build/libgit2-darwin-arm64/lib/libssl.a  
-          libtool -static -o ./libgit2-darwin/lib/libz.a \
+
+          libtool -static -o ./libgit2-darwin-libgit2-all/lib/libz.a \
             ${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64/lib/libz.a \
             ${GITHUB_WORKSPACE}/build/libgit2-darwin-arm64/lib/libz.a 
 
-          tar -zcvf darwin-libs.tar.gz libgit2-darwin
+          tar -zcvf darwin-libgit2-all-libs.tar.gz libgit2-darwin-libgit2-all
+          rm -rf ${GITHUB_WORKSPACE}/build ${GITHUB_WORKSPACE}/libgit2
         env:
           MACOSX_DEPLOYMENT_TARGET: 10.15
       - name: Upload Release Asset
-        id: upload-release-asset 
+        id: upload-release-asset-libgit2-all
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           upload_url: ${{ needs.github_release.outputs.release_upload_url }}
-          asset_path: ./darwin-libs.tar.gz
-          asset_name: darwin-libs.tar.gz
+          asset_path: ./darwin-libgit2-all-libs.tar.gz
+          asset_name: darwin-libgit2-all-libs.tar.gz
+          asset_content_type: application/gzip
+
+      - name: Build universal static libraries for Darwin - libgit2 only
+        run: |
+          TARGET_DIR=${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64 \
+          BUILD_ROOT_DIR=${GITHUB_WORKSPACE}/libgit2/build/amd \
+          ./hack/static.sh build_libgit2_only
+
+          TARGET_DIR=${GITHUB_WORKSPACE}/build/libgit2-darwin-arm64 \
+          BUILD_ROOT_DIR=${GITHUB_WORKSPACE}/libgit2/build/arm \
+          TARGET_ARCH=arm64 \
+          CMAKE_APPLE_SILICON_PROCESSOR=arm64 \
+          ./hack/static.sh build_libgit2_only
+
+          mkdir -p ./libgit2-darwin-libgit2-only
+          mv ${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64/include ./libgit2-darwin-libgit2-only/
+          mv ${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64/lib ./libgit2-darwin-libgit2-only/
+
+          libtool -static -o ./libgit2-darwin-libgit2-only/lib/libgit2.a \
+            ${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64/lib/libgit2.a \
+            ${GITHUB_WORKSPACE}/build/libgit2-darwin-arm64/lib/libgit2.a
+
+          tar -zcvf darwin-libs-libgit2-only.tar.gz libgit2-darwin-libgit2-only
+          rm -rf ${GITHUB_WORKSPACE}/build ${GITHUB_WORKSPACE}/libgit2
+        env:
+          MACOSX_DEPLOYMENT_TARGET: 10.15
+      - name: Upload Release Asset
+        id: upload-release-asset-libgit2-only
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ needs.github_release.outputs.release_upload_url }}
+          asset_path: ./darwin-libs-libgit2-only.tar.gz
+          asset_name: darwin-libs-libgit2-only.tar.gz
           asset_content_type: application/gzip

--- a/Dockerfile.libgit2-only
+++ b/Dockerfile.libgit2-only
@@ -1,0 +1,66 @@
+# This Dockerfile tests the hack/Makefile output against git2go.
+ARG BASE_VARIANT=alpine
+ARG GO_VERSION=1.17
+ARG XX_VERSION=1.1.0
+
+FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx
+
+FROM --platform=$BUILDPLATFORM ${BASE_VARIANT} AS build-base
+
+RUN apk add --no-cache \
+        bash \
+        curl \
+        build-base \
+        linux-headers \
+        perl \
+        cmake \
+        pkgconfig \
+        gcc \
+        musl-dev \
+        clang \
+        lld
+
+COPY --from=xx / /
+
+FROM build-base AS build-cross
+
+ARG TARGETPLATFORM
+
+RUN xx-apk add --no-cache \
+        build-base \
+        pkgconfig \
+        gcc \
+        musl-dev \
+        clang \
+        lld \
+        llvm \
+        linux-headers
+
+WORKDIR /build
+COPY hack/static.sh .
+
+ENV CC=xx-clang
+ENV CXX=xx-clang++
+
+RUN ./static.sh build_libgit2_only
+
+# trimmed removes all non necessary files (i.e. openssl binary).
+FROM build-cross AS trimmed
+
+ARG TARGETPLATFORM
+RUN mkdir -p /trimmed/usr/local/$(xx-info triple)/ && \
+        mkdir -p /trimmed/usr/local/$(xx-info triple)/share
+
+RUN cp -r /usr/local/$(xx-info triple)/lib/ /trimmed/usr/local/$(xx-info triple)/ && \
+        cp -r /usr/local/$(xx-info triple)/include/ /trimmed/usr/local/$(xx-info triple)/
+
+FROM scratch as libs-arm64
+COPY --from=trimmed /trimmed/ /
+
+FROM scratch as libs-amd64
+COPY --from=trimmed /trimmed/ /
+
+FROM scratch as libs-armv7
+COPY --from=trimmed /trimmed/ /
+
+FROM libs-$TARGETARCH$TARGETVARIANT as libs

--- a/Dockerfile.test-libgit2-only
+++ b/Dockerfile.test-libgit2-only
@@ -1,6 +1,6 @@
 # This Dockerfile tests the hack/Makefile output against git2go.
 ARG BASE_VARIANT=alpine
-ARG GO_VERSION=1.18
+ARG GO_VERSION=1.17
 ARG XX_VERSION=1.1.0
 
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx
@@ -42,20 +42,7 @@ COPY hack/static.sh .
 ENV CC=xx-clang
 ENV CXX=xx-clang++
 
-RUN CHOST=$(xx-clang --print-target-triple) \
-    ./static.sh build_libz
-
-RUN CHOST=$(xx-clang --print-target-triple) \
-    ./static.sh build_openssl
-
-RUN export LIBRARY_PATH="/usr/local/$(xx-info triple)/lib:/usr/local/$(xx-info triple)/lib64:${LIBRARY_PATH}" && \
-    export PKG_CONFIG_PATH="/usr/local/$(xx-info triple)/lib/pkgconfig:/usr/local/$(xx-info triple)/lib64/pkgconfig" && \
-    export OPENSSL_ROOT_DIR="/usr/local/$(xx-info triple)" && \
-    export OPENSSL_CRYPTO_LIBRARY="/usr/local/$(xx-info triple)/lib64" && \
-    export OPENSSL_INCLUDE_DIR="/usr/local/$(xx-info triple)/include/openssl"
-
-RUN ./static.sh build_libssh2
-RUN ./static.sh build_libgit2
+RUN ./static.sh build_libgit2_only
 
 # trimmed removes all non necessary files (i.e. openssl binary).
 FROM build-cross AS trimmed
@@ -65,9 +52,7 @@ RUN mkdir -p /trimmed/usr/local/$(xx-info triple)/ && \
         mkdir -p /trimmed/usr/local/$(xx-info triple)/share
 
 RUN cp -r /usr/local/$(xx-info triple)/lib/ /trimmed/usr/local/$(xx-info triple)/ && \
-        cp -r /usr/local/$(xx-info triple)/lib64/ /trimmed/usr/local/$(xx-info triple)/ | true && \
-        cp -r /usr/local/$(xx-info triple)/include/ /trimmed/usr/local/$(xx-info triple)/ && \
-        cp -r /usr/local/$(xx-info triple)/share/doc/ /trimmed/usr/local/$(xx-info triple)/share/
+        cp -r /usr/local/$(xx-info triple)/include/ /trimmed/usr/local/$(xx-info triple)/
 
 FROM scratch as libs-arm64
 COPY --from=trimmed /trimmed/ /
@@ -118,9 +103,9 @@ COPY tests/smoketest/main.go .
 COPY --from=libs /usr/local/ /usr/local/
 
 ENV CGO_ENABLED=1
-RUN export LIBRARY_PATH="/usr/local/$(xx-info triple):/usr/local/$(xx-info triple)/lib64" && \
-    export PKG_CONFIG_PATH="/usr/local/$(xx-info triple)/lib/pkgconfig:/usr/local/$(xx-info triple)/lib64/pkgconfig" && \
-    export FLAGS="$(pkg-config --static --libs --cflags libssh2 openssl libgit2)" && \
+RUN export LIBRARY_PATH="/usr/local/$(xx-info triple)" && \
+    export PKG_CONFIG_PATH="/usr/local/$(xx-info triple)/lib/pkgconfig" && \
+    export FLAGS="$(pkg-config --static --libs --cflags libgit2)" && \
     export CGO_LDFLAGS="${FLAGS} -static" && \
     xx-go build  \
         -ldflags "-s -w" \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 TAG ?= latest
-ifeq($(LIBGIT2_ONLY),true)
+
+ifeq ($(LIBGIT2_ONLY),true)
 	IMG ?= ghcr.io/fluxcd/golang-with-libgit2-only
 else
 	IMG ?= ghcr.io/fluxcd/golang-with-libgit2-all

--- a/hack/static.sh
+++ b/hack/static.sh
@@ -188,6 +188,44 @@ function build_libgit2(){
     popd
 }
 
+function build_libgit2_only(){
+    download_source "${LIBGIT2_URL}" "${SRC_DIR}/libgit2"
+
+    pushd "${SRC_DIR}/libgit2"
+
+    mkdir -p build
+
+    pushd build
+
+    # Set osx arch only when cross compiling on darwin
+    if [[ $OSTYPE == darwin* ]] && [ ! "${TARGET_ARCH}" = "$(uname -m)" ]; then
+        CMAKE_PARAMS=-DCMAKE_OSX_ARCHITECTURES="${TARGET_ARCH}"
+    fi
+
+    cmake "${CMAKE_PARAMS}" \
+    -DCMAKE_C_COMPILER="${C_COMPILER}" \
+    -DCMAKE_INSTALL_PREFIX="${TARGET_DIR}" \
+    -DTHREADSAFE:BOOL=ON \
+    -DBUILD_CLAR:BOOL=OFF \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON \
+    -DCMAKE_C_FLAGS=-fPIC \
+    -DUSE_SSH:BOOL=OFF \
+    -DHAVE_LIBSSH2_MEMORY_CREDENTIALS:BOOL=OFF \
+    -DDEPRECATE_HARD:BOOL=ON \
+    -DUSE_BUNDLED_ZLIB:BOOL=ON \
+    -DUSE_HTTPS:STRING:BOOL=OFF \
+    -DREGEX_BACKEND:STRING=builtin \
+    -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
+    ..
+
+
+    cmake --build . --target install
+
+    popd
+    popd
+}
+
 function all(){
     build_libz
     build_openssl


### PR DESCRIPTION
This PR adds support for building `libgit2` without linking with `openssl` and `libssh2`. This can be done by running
`hack/static.sh build_libgit2_only` or `LIBGIT2_ONLY=true make build`.

Further modifies, the CI workflows to release four artifacts:
* `linux-x86_64-libgit2-only-lib.tar.gz` (new)
* `linux-x86_64-libgit2-all-libs.tar.gz` (replacing `linux-x86_64-libs.tar.gz`)
* `darwin-libs-libgit2-only.tar.gz` (new)
* `darwin-libgit2-all-libs.tar.gz` (replacing `darwin-libs.tar.gz`)