### PR TITLE
Set new semver format based for releases tags

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -92,26 +92,13 @@ jobs:
           tags: localhost:5000/${{ github.repository_owner }}/golang-with-libgit2-all:latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-      - name: Build candidate image - libgit2 only
-        id: build_candidate_libgti2_only
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          file: Dockerfile.libgit2-only
-          platforms: ${{ env.PLATFORMS }}
-          push: true
-          tags: localhost:5000/${{ github.repository_owner }}/golang-with-libgit2-only:latest
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
       - name: Inspect candidate images
         run: |
           docker buildx imagetools inspect localhost:5000/${{ github.repository_owner }}/golang-with-libgit2-all:latest
-          docker buildx imagetools inspect localhost:5000/${{ github.repository_owner }}/golang-with-libgit2-only:latest
       - name: Test candidate images
         id: test_candidate
         run: |
           IMG=localhost:5000/${{ github.repository_owner }}/golang-with-libgit2-all make test
-          IMG=localhost:5000/${{ github.repository_owner }}/golang-with-libgit2-only LIBGIT2_ONLY=true make test
       - # Temp fix
         # https://github.com/docker/build-push-action/issues/252
         # https://github.com/moby/buildkit/issues/1896
@@ -134,9 +121,7 @@ jobs:
           images: |
             ghcr.io/${{ github.repository_owner }}/golang-with-libgit2-all
           tags: |
-            type=schedule
-            type=ref,event=branch
-            type=ref,event=tag
+            type=semver,pattern=v{{version}}
             type=sha
             type=sha,format=long
       - name: Release candidate image - golang-with-libgit2-all
@@ -162,6 +147,85 @@ jobs:
             cosign sign $image
           done
 
+  build-libgit2-only:
+    runs-on: ubuntu-latest
+    env:
+      PLATFORMS: linux/amd64,linux/arm/v7,linux/arm64
+    services:
+      registry:
+        image: registry:2
+        ports:
+         - 5000:5000
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+      - name: Setup Cosign
+        uses: sigstore/cosign-installer@main
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v2
+        with:
+          image: tonistiigi/binfmt:latest
+          platforms: ${{ env.PLATFORMS }}
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          config-inline: |
+            [worker.oci]
+              max-parallelism = 4
+          driver-opts: network=host
+      - name: Inspect builder
+        run: |
+          echo "Name:      ${{ steps.buildx.outputs.name }}"
+          echo "Endpoint:  ${{ steps.buildx.outputs.endpoint }}"
+          echo "Status:    ${{ steps.buildx.outputs.status }}"
+          echo "Flags:     ${{ steps.buildx.outputs.flags }}"
+          echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        id: cache
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-ghcache-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-ghcache-
+      - run: cat ./hack/static.sh
+      - name: Build candidate image - libgit2 only
+        id: build_candidate_libgti2_only
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: Dockerfile.libgit2-only
+          platforms: ${{ env.PLATFORMS }}
+          push: true
+          tags: localhost:5000/${{ github.repository_owner }}/golang-with-libgit2-only:latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+      - name: Inspect candidate images
+        run: |
+          docker buildx imagetools inspect localhost:5000/${{ github.repository_owner }}/golang-with-libgit2-only:latest
+      - name: Test candidate images
+        id: test_candidate
+        run: |
+          IMG=localhost:5000/${{ github.repository_owner }}/golang-with-libgit2-only LIBGIT2_ONLY=true make test
+      - # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+      - name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Compose release candidate metadata - golang-with-libgit2-only
         id: meta_libgit2_only
         uses: docker/metadata-action@v3
@@ -170,9 +234,7 @@ jobs:
           images: |
             ghcr.io/${{ github.repository_owner }}/golang-with-libgit2-only
           tags: |
-            type=schedule
-            type=ref,event=branch
-            type=ref,event=tag
+            type=semver,pattern=v{{version}}
             type=sha
             type=sha,format=long
       - name: Release candidate image - golang-with-libgit2-only

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: macos-11
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Test build script for darwin-amd64 - libgit2-all
         run: |
           make dev-test
@@ -46,20 +46,20 @@ jobs:
          - 5000:5000
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Unshallow
         run: git fetch --prune --unshallow
       - name: Setup Cosign
         uses: sigstore/cosign-installer@main
       - name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
         with:
           image: tonistiigi/binfmt:latest
           platforms: ${{ env.PLATFORMS }}
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
         with:
           config-inline: |
             [worker.oci]
@@ -73,7 +73,7 @@ jobs:
           echo "Flags:     ${{ steps.buildx.outputs.flags }}"
           echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache
         with:
           path: /tmp/.buildx-cache
@@ -83,7 +83,7 @@ jobs:
       - run: cat ./hack/static.sh
       - name: Build candidate image - libgit2 compiled with libssh2 and openssl
         id: build_candidate_libgit2_all
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: Dockerfile
@@ -94,7 +94,7 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
       - name: Build candidate image - libgit2 only
         id: build_candidate_libgti2_only
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: Dockerfile.libgit2-only
@@ -121,7 +121,7 @@ jobs:
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
       - name: Login to GHCR
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -142,7 +142,7 @@ jobs:
       - name: Release candidate image - golang-with-libgit2-all
         id: release_candidate_libgit2_all
         if: github.event_name != 'pull_request'
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: Dockerfile
@@ -178,7 +178,7 @@ jobs:
       - name: Release candidate image - golang-with-libgit2-only
         id: release_candidate_libgit2_only
         if: github.event_name != 'pull_request'
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: Dockerfile.libgit2-only

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build static libraries - libgit2 compiled with libssh2 and openssl
         run: |
           TARGET_DIR=${GITHUB_WORKSPACE}/build/libgit2-linux \
@@ -71,7 +71,7 @@ jobs:
     runs-on: macos-11
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build universal static libraries for Darwin - libgit2 compiled with libssh2 and openssl
         run: |
           TARGET_DIR=${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64 \
@@ -151,10 +151,10 @@ jobs:
     needs: [linux-amd64-release, darwin-release]
     if:  ${{ always() && contains(join(needs.*.result, ','), 'success') }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: 1.17.x
       - name: Setup Cosign

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -156,7 +156,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
       - name: Setup Cosign
         uses: sigstore/cosign-installer@main
       - name: Setup Syft

--- a/Dockerfile.libgit2-only
+++ b/Dockerfile.libgit2-only
@@ -1,7 +1,7 @@
 # This Dockerfile builds and packages libgit2 only (not linked with openssl and libssh2)
 
 ARG BASE_VARIANT=alpine
-ARG GO_VERSION=1.17
+ARG GO_VERSION=1.18
 ARG XX_VERSION=1.1.0
 
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx

--- a/Dockerfile.test-libgit2-only
+++ b/Dockerfile.test-libgit2-only
@@ -1,7 +1,7 @@
 # This Dockerfile builds and packages libgit2 only (not linked with openssl and libssh2); and tests it against git2go.
 
 ARG BASE_VARIANT=alpine
-ARG GO_VERSION=1.17
+ARG GO_VERSION=1.18
 ARG XX_VERSION=1.1.0
 
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx

--- a/README.md
+++ b/README.md
@@ -94,13 +94,9 @@ FROM go-${BASE_VARIANT} AS build-dependencies-awesome-os
 ### Releasing a new image
 
 For the `main` branch, images are pushed automatically to a tag matching the branch name, and a tag in the format of
-`sha-<Git sha>`. In addition, images are created for new tags, with as preferred format: `libgit2-<libgit2 SemVer>`.
+`sha-<Git sha>`. In addition, images are created for new tags, with as preferred format: `v<SemVer>`.
 
-For example, `libgit2-1.1.1` for an image with **libgit2 1.1.1** included.
-
-In case changes happen to the `Dockerfile` while the `libgit2` version does not change, sequential tags should
-be suffixed with `-<seq num in range>`. For example, `libgit2-1.1.1-2` for the **third** container image
-with the same version.
+For example, `v0.1.0`.
 
 ### Debugging cross-compilation
 

--- a/tests/smoketest/go.mod
+++ b/tests/smoketest/go.mod
@@ -1,6 +1,6 @@
 module github.com/fluxcd/golang-with-libgit2/tests/sample
 
-go 1.17
+go 1.18
 
 require (
 	github.com/fluxcd/pkg/gittestserver v0.5.2


### PR DESCRIPTION
Changes:
- Update GH actions to latest versions.
- Consolidate use of Go 1.18 across the project.
- Update semver format for release tags (e.g. `v0.1.0` instead of `libgit2-1.3.1-6`).

Fixes regression from #28.
Closes #21.

xref: https://github.com/fluxcd/golang-with-libgit2/runs/7231071749?check_suite_focus=true