### PR TITLE
Align name of release files for easier consumption

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,31 +17,9 @@ permissions:
   id-token: write # needed for keyless signing
 
 jobs:
-
-  darwin-all-libs-test:
-    runs-on: macos-11
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Test build script for darwin-amd64 - libgit2-all
-        run: |
-          make dev-test
-          rm -rf ${GITHUB_WORKSPACE}/build rm -rf ${GITHUB_WORKSPACE}/libgit2
-        env:
-          MACOSX_DEPLOYMENT_TARGET: 10.15
-
-  darwin-libgit2-only-test:
-    runs-on: macos-11
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Test build script for darwin-amd64 - libgit2-only
-        run: |
-          LIBGIT2_ONLY=true make dev-test
-        env:
-          MACOSX_DEPLOYMENT_TARGET: 10.15
-
-  docker-build-all-libs:
+  # changing this job name for some reason caused GitHub checks to
+  # hang at `Expected — Waiting for status to be reported`. 
+  build:
     runs-on: ubuntu-latest
     env:
       PLATFORMS: linux/amd64,linux/arm/v7,linux/arm64

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
 
-  mac-build:
+  darwin-all-libs-test:
     runs-on: macos-11
     steps:
       - name: Checkout
@@ -29,13 +29,19 @@ jobs:
           rm -rf ${GITHUB_WORKSPACE}/build rm -rf ${GITHUB_WORKSPACE}/libgit2
         env:
           MACOSX_DEPLOYMENT_TARGET: 10.15
+
+  darwin-libgit2-only-test:
+    runs-on: macos-11
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
       - name: Test build script for darwin-amd64 - libgit2-only
         run: |
           LIBGIT2_ONLY=true make dev-test
         env:
           MACOSX_DEPLOYMENT_TARGET: 10.15
 
-  build:
+  docker-build-all-libs:
     runs-on: ubuntu-latest
     env:
       PLATFORMS: linux/amd64,linux/arm/v7,linux/arm64
@@ -147,7 +153,7 @@ jobs:
             cosign sign $image
           done
 
-  build-libgit2-only:
+  docker-build-libgit2-only:
     runs-on: ubuntu-latest
     env:
       PLATFORMS: linux/amd64,linux/arm/v7,linux/arm64

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,37 +19,24 @@ permissions:
 
 jobs:
 
-  linux-amd64-release:
+  linux-x86_64-all-libs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Build static libraries - libgit2 compiled with libssh2 and openssl
         run: |
-          TARGET_DIR=${GITHUB_WORKSPACE}/build/libgit2-linux \
+          TARGET_DIR=${GITHUB_WORKSPACE}/build/libgit2-linux-all-libs \
           BUILD_ROOT_DIR=${GITHUB_WORKSPACE}/libgit2/build/amd \
           ./hack/static.sh all
           
-          mkdir -p ./libgit2-linux-libgit2-all/
-          mv ${GITHUB_WORKSPACE}/build/libgit2-linux/include ./libgit2-linux-libgit2-all/
-          mv ${GITHUB_WORKSPACE}/build/libgit2-linux/share ./libgit2-linux-libgit2-all/
-          mv ${GITHUB_WORKSPACE}/build/libgit2-linux/lib ./libgit2-linux-libgit2-all/
-          mv ${GITHUB_WORKSPACE}/build/libgit2-linux/lib64 ./libgit2-linux-libgit2-all/
+          mkdir -p ./libgit2-linux-all-libs/
+          mv ${GITHUB_WORKSPACE}/build/libgit2-linux-all-libs/include ./libgit2-linux-all-libs/
+          mv ${GITHUB_WORKSPACE}/build/libgit2-linux-all-libs/share ./libgit2-linux-all-libs/
+          mv ${GITHUB_WORKSPACE}/build/libgit2-linux-all-libs/lib ./libgit2-linux-all-libs/
+          mv ${GITHUB_WORKSPACE}/build/libgit2-linux-all-libs/lib64 ./libgit2-linux-all-libs/
 
-          tar -zcvf linux-x86_64-libgit2-all-libs.tar.gz libgit2-linux-libgit2-all
-          rm -rf ${GITHUB_WORKSPACE}/build ${GITHUB_WORKSPACE}/libgit2
-
-      - name: Build static libraries - libgit2 only
-        run: |
-          TARGET_DIR=${GITHUB_WORKSPACE}/build/libgit2-linux \
-          BUILD_ROOT_DIR=${GITHUB_WORKSPACE}/libgit2/build/amd \
-          ./hack/static.sh build_libgit2_only
-
-          mkdir -p ./libgit2-linux-libgit2-only/
-          mv ${GITHUB_WORKSPACE}/build/libgit2-linux/include ./libgit2-linux-libgit2-only/
-          mv ${GITHUB_WORKSPACE}/build/libgit2-linux/lib ./libgit2-linux-libgit2-only/
-
-          tar -zcvf linux-x86_64-libgit2-only-lib.tar.gz libgit2-linux-libgit2-only
+          tar -zcvf linux-x86_64-all-libs.tar.gz libgit2-linux-all-libs
           rm -rf ${GITHUB_WORKSPACE}/build ${GITHUB_WORKSPACE}/libgit2
       - uses: actions/upload-artifact@v3
         with:
@@ -57,7 +44,30 @@ jobs:
           path: '*.tar.gz'
           if-no-files-found: error
 
-  darwin-release:
+  linux-x86_64-libgit2-only:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build static libraries - libgit2 only
+        run: |
+          TARGET_DIR=${GITHUB_WORKSPACE}/build/build_libgit2_only \
+          BUILD_ROOT_DIR=${GITHUB_WORKSPACE}/libgit2/build/amd \
+          ./hack/static.sh build_libgit2_only
+
+          mkdir -p ./linux-libgit2-only/
+          mv ${GITHUB_WORKSPACE}/build/build_libgit2_only/include ./linux-libgit2-only/
+          mv ${GITHUB_WORKSPACE}/build/build_libgit2_only/lib ./linux-libgit2-only/
+
+          tar -zcvf linux-x86_64-libgit2-only.tar.gz linux-libgit2-only
+          rm -rf ${GITHUB_WORKSPACE}/build ${GITHUB_WORKSPACE}/libgit2
+      - uses: actions/upload-artifact@v3
+        with:
+          name: release-artifact
+          path: '*.tar.gz'
+          if-no-files-found: error
+
+  darwin-all-libs:
     # This job builds and releases "universal libraries" that are
     # supported by both darwin-amd64 and darwin-arm64.
     #
@@ -74,7 +84,10 @@ jobs:
         uses: actions/checkout@v3
       - name: Build universal static libraries for Darwin - libgit2 compiled with libssh2 and openssl
         run: |
-          TARGET_DIR=${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64 \
+          # The amd64 is used as base, using the target dir name (darwin-all-libs)
+          # instead of the platform specific one, removes the need of replacing the
+          # path in the .pc files.
+          TARGET_DIR=${GITHUB_WORKSPACE}/build/darwin-all-libs \
           BUILD_ROOT_DIR=${GITHUB_WORKSPACE}/libgit2/build/amd \
           ./hack/static.sh all
           
@@ -84,39 +97,65 @@ jobs:
           CMAKE_APPLE_SILICON_PROCESSOR=arm64 \
           ./hack/static.sh all
 
-          mkdir -p ./libgit2-darwin-libgit2-all/lib
-          mv ${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64/include ./libgit2-darwin-libgit2-all/
-          mv ${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64/share ./libgit2-darwin-libgit2-all/
-          mv ${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64/lib/cmake ./libgit2-darwin-libgit2-all/lib/
-          mv ${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64/lib/engines-3 ./libgit2-darwin-libgit2-all/lib/
-          mv ${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64/lib/ossl-modules ./libgit2-darwin-libgit2-all/lib/
-          mv ${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64/lib/pkgconfig ./libgit2-darwin-libgit2-all/lib/
 
-          libtool -static -o ./libgit2-darwin-libgit2-all/lib/libcrypto.a \
-            ${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64/lib/libcrypto.a \
+          LIBGIT2_SED="s;-L/Applications/Xcode_.* ;;g"
+          LIBGIT2PC="${GITHUB_WORKSPACE}/build/darwin-all-libs/lib/pkgconfig/libgit2.pc"          
+
+          # pkgconfig files may contain absolute paths to its dependencies that is specific
+          # to the runner - machine used to compile the library. 
+          # We need to remove the absolute path of iconv, so when the library is consumed
+          # pkgconfig will automatically try to find it through the default search paths
+          # on the target machine.
+          if command -v gsed &> /dev/null; then 
+              gsed -i "${LIBGIT2_SED}" "${LIBGIT2PC}"
+          else
+              sed -i "" "${LIBGIT2_SED}" "${LIBGIT2PC}"
+          fi
+
+          mkdir -p ./darwin-all-libs/lib
+          mv ${GITHUB_WORKSPACE}/build/darwin-all-libs/include ./darwin-all-libs/
+          mv ${GITHUB_WORKSPACE}/build/darwin-all-libs/share ./darwin-all-libs/
+          mv ${GITHUB_WORKSPACE}/build/darwin-all-libs/lib/cmake ./darwin-all-libs/lib/
+          mv ${GITHUB_WORKSPACE}/build/darwin-all-libs/lib/engines-3 ./darwin-all-libs/lib/
+          mv ${GITHUB_WORKSPACE}/build/darwin-all-libs/lib/ossl-modules ./darwin-all-libs/lib/
+          mv ${GITHUB_WORKSPACE}/build/darwin-all-libs/lib/pkgconfig ./darwin-all-libs/lib/
+
+          libtool -static -o ./darwin-all-libs/lib/libcrypto.a \
+            ${GITHUB_WORKSPACE}/build/darwin-all-libs/lib/libcrypto.a \
             ${GITHUB_WORKSPACE}/build/libgit2-darwin-arm64/lib/libcrypto.a 
 
-          libtool -static -o ./libgit2-darwin-libgit2-all/lib/libgit2.a \
-            ${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64/lib/libgit2.a \
+          libtool -static -o ./darwin-all-libs/lib/libgit2.a \
+            ${GITHUB_WORKSPACE}/build/darwin-all-libs/lib/libgit2.a \
             ${GITHUB_WORKSPACE}/build/libgit2-darwin-arm64/lib/libgit2.a 
 
-          libtool -static -o ./libgit2-darwin-libgit2-all/lib/libssh2.a \
-            ${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64/lib/libssh2.a \
+          libtool -static -o ./darwin-all-libs/lib/libssh2.a \
+            ${GITHUB_WORKSPACE}/build/darwin-all-libs/lib/libssh2.a \
             ${GITHUB_WORKSPACE}/build/libgit2-darwin-arm64/lib/libssh2.a 
 
-          libtool -static -o ./libgit2-darwin-libgit2-all/lib/libssl.a \
-            ${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64/lib/libssl.a \
+          libtool -static -o ./darwin-all-libs/lib/libssl.a \
+            ${GITHUB_WORKSPACE}/build/darwin-all-libs/lib/libssl.a \
             ${GITHUB_WORKSPACE}/build/libgit2-darwin-arm64/lib/libssl.a  
 
-          libtool -static -o ./libgit2-darwin-libgit2-all/lib/libz.a \
-            ${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64/lib/libz.a \
+          libtool -static -o ./darwin-all-libs/lib/libz.a \
+            ${GITHUB_WORKSPACE}/build/darwin-all-libs/lib/libz.a \
             ${GITHUB_WORKSPACE}/build/libgit2-darwin-arm64/lib/libz.a 
 
-          tar -zcvf darwin-libgit2-all-libs.tar.gz libgit2-darwin-libgit2-all
+          tar -zcvf darwin-all-libs.tar.gz darwin-all-libs
           rm -rf ${GITHUB_WORKSPACE}/build ${GITHUB_WORKSPACE}/libgit2
         env:
           MACOSX_DEPLOYMENT_TARGET: 10.15
+      - uses: actions/upload-artifact@v3
+        with:
+          name: release-artifact
+          path: '*.tar.gz'
+          if-no-files-found: error
 
+  # similar to darwin-all-libs, but only compiles libgit2.
+  darwin-libgit2-only:
+    runs-on: macos-11
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
       - name: Build universal static libraries for Darwin - libgit2 only
         run: |
           TARGET_DIR=${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64 \
@@ -129,14 +168,14 @@ jobs:
           CMAKE_APPLE_SILICON_PROCESSOR=arm64 \
           ./hack/static.sh build_libgit2_only
 
-          mkdir -p ./libgit2-darwin-libgit2-only/lib
-          mv ${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64/include ./libgit2-darwin-libgit2-only/
+          mkdir -p ./darwin-libgit2-only/lib
+          mv ${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64/include ./darwin-libgit2-only/
 
-          libtool -static -o ./libgit2-darwin-libgit2-only/lib/libgit2.a \
+          libtool -static -o ./darwin-libgit2-only/lib/libgit2.a \
             ${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64/lib/libgit2.a \
             ${GITHUB_WORKSPACE}/build/libgit2-darwin-arm64/lib/libgit2.a
 
-          tar -zcvf darwin-libs-libgit2-only.tar.gz libgit2-darwin-libgit2-only
+          tar -zcvf darwin-libgit2-only.tar.gz darwin-libgit2-only
           rm -rf ${GITHUB_WORKSPACE}/build ${GITHUB_WORKSPACE}/libgit2
         env:
           MACOSX_DEPLOYMENT_TARGET: 10.15
@@ -148,7 +187,7 @@ jobs:
 
   goreleaser:
     runs-on: ubuntu-latest
-    needs: [linux-amd64-release, darwin-release]
+    needs: [linux-x86_64-all-libs, linux-x86_64-libgit2-only, darwin-all-libs, darwin-libgit2-only]
     if:  ${{ always() && contains(join(needs.*.result, ','), 'success') }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,13 +12,11 @@ on:
         default: 'rc'
         required: true
 
-
 permissions:
   contents: write # needed to write releases
   id-token: write # needed for keyless signing
 
 jobs:
-
   linux-x86_64-all-libs:
     runs-on: ubuntu-latest
     steps:
@@ -29,7 +27,7 @@ jobs:
           TARGET_DIR=${GITHUB_WORKSPACE}/build/libgit2-linux-all-libs \
           BUILD_ROOT_DIR=${GITHUB_WORKSPACE}/libgit2/build/amd \
           ./hack/static.sh all
-          
+
           mkdir -p ./libgit2-linux-all-libs/
           mv ${GITHUB_WORKSPACE}/build/libgit2-linux-all-libs/include ./libgit2-linux-all-libs/
           mv ${GITHUB_WORKSPACE}/build/libgit2-linux-all-libs/share ./libgit2-linux-all-libs/
@@ -41,7 +39,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: release-artifact
-          path: '*.tar.gz'
+          path: "*.tar.gz"
           if-no-files-found: error
 
   linux-x86_64-libgit2-only:
@@ -64,7 +62,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: release-artifact
-          path: '*.tar.gz'
+          path: "*.tar.gz"
           if-no-files-found: error
 
   darwin-all-libs:
@@ -75,8 +73,8 @@ jobs:
     # both outcomes onto a single binary for each static library.
     #
     # `macos-11` has been picked as support for arm64 was only added on Xcode 12.
-    # Although some minor versions of Catalina 10.15 can support it, at the time 
-    # of testing, GitHub's macos-10.15 did not seem to. 
+    # Although some minor versions of Catalina 10.15 can support it, at the time
+    # of testing, GitHub's macos-10.15 did not seem to.
     # Cross-compiling to arm64 on that runner consistently failed.
     runs-on: macos-11
     steps:
@@ -90,7 +88,7 @@ jobs:
           TARGET_DIR=${GITHUB_WORKSPACE}/build/darwin-all-libs \
           BUILD_ROOT_DIR=${GITHUB_WORKSPACE}/libgit2/build/amd \
           ./hack/static.sh all
-          
+
           TARGET_DIR=${GITHUB_WORKSPACE}/build/libgit2-darwin-arm64 \
           BUILD_ROOT_DIR=${GITHUB_WORKSPACE}/libgit2/build/arm \
           TARGET_ARCH=arm64 \
@@ -98,14 +96,13 @@ jobs:
           ./hack/static.sh all
 
 
-          LIBGIT2_SED="s;-L/Applications/Xcode_.* ;;g"
+          LIBGIT2_SED="s;-L/Applications/Xcode.* ;;g"
           LIBGIT2PC="${GITHUB_WORKSPACE}/build/darwin-all-libs/lib/pkgconfig/libgit2.pc"          
 
-          # pkgconfig files may contain absolute paths to its dependencies that is specific
-          # to the runner - machine used to compile the library. 
-          # We need to remove the absolute path of iconv, so when the library is consumed
-          # pkgconfig will automatically try to find it through the default search paths
-          # on the target machine.
+          # pkgconfig includes absolute paths that are specific to the runner machine. 
+          # We need to remove the absolute path for iconv, so when the libgit2 library
+          # is consumed pkgconfig will automatically try to find it through the default
+          # search paths on the target machine.
           if command -v gsed &> /dev/null; then 
               gsed -i "${LIBGIT2_SED}" "${LIBGIT2PC}"
           else
@@ -147,7 +144,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: release-artifact
-          path: '*.tar.gz'
+          path: "*.tar.gz"
           if-no-files-found: error
 
   # similar to darwin-all-libs, but only compiles libgit2.
@@ -168,6 +165,19 @@ jobs:
           CMAKE_APPLE_SILICON_PROCESSOR=arm64 \
           ./hack/static.sh build_libgit2_only
 
+          LIBGIT2_SED="s;-L/Applications/Xcode.* ;;g"
+          LIBGIT2PC="${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64/lib/pkgconfig/libgit2.pc"          
+
+          # pkgconfig includes absolute paths that are specific to the runner machine. 
+          # We need to remove the absolute path for iconv, so when the libgit2 library
+          # is consumed pkgconfig will automatically try to find it through the default
+          # search paths on the target machine.
+          if command -v gsed &> /dev/null; then 
+              gsed -i "${LIBGIT2_SED}" "${LIBGIT2PC}"
+          else
+              sed -i "" "${LIBGIT2_SED}" "${LIBGIT2PC}"
+          fi
+
           mkdir -p ./darwin-libgit2-only/lib
           mv ${GITHUB_WORKSPACE}/build/libgit2-darwin-amd64/include ./darwin-libgit2-only/
 
@@ -182,13 +192,19 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: release-artifact
-          path: '*.tar.gz'
+          path: "*.tar.gz"
           if-no-files-found: error
 
   goreleaser:
     runs-on: ubuntu-latest
-    needs: [linux-x86_64-all-libs, linux-x86_64-libgit2-only, darwin-all-libs, darwin-libgit2-only]
-    if:  ${{ always() && contains(join(needs.*.result, ','), 'success') }}
+    needs:
+      [
+        linux-x86_64-all-libs,
+        linux-x86_64-libgit2-only,
+        darwin-all-libs,
+        darwin-libgit2-only,
+      ]
+    if: ${{ always() && contains(join(needs.*.result, ','), 'success') }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,45 @@
+---
+name: "Test"
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - README.md
+  pull_request:
+    paths-ignore:
+      - README.md
+
+permissions: {}
+
+jobs:
+  darwin-dev-test:
+    strategy:
+      matrix:
+        libgit_only: [true, false]
+    runs-on: macos-11
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Test build script for darwin-amd64
+        run: |
+          rm -rf ${GITHUB_WORKSPACE}/build
+          make dev-test
+        env:
+          LIBGIT2_ONLY: ${{ matrix.libgit_only }}
+          MACOSX_DEPLOYMENT_TARGET: 10.15
+
+  linux-dev-test:
+    strategy:
+      matrix:
+        libgit_only: [true, false]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Test build script for linux-amd64
+        run: |
+          rm -rf ${GITHUB_WORKSPACE}/build
+          make dev-test
+        env:
+          LIBGIT2_ONLY: ${{ matrix.libgit_only }}


### PR DESCRIPTION
This PR also split workflows in the attempt to decrease the time required to build/release.

Note that the workflow split between `all-libs` and `libgit2-only` is a step stone towards the decommissioning of Managed Transport. Once that takes place we no longer will require `all-libs` and the compilation times that comes with it.

Relates to https://github.com/fluxcd/source-controller/issues/820 and https://github.com/fluxcd/image-automation-controller/issues/404.