### PR TITLE
Upgrade to libgit2 v1.3.2

### DIFF
--- a/hack/static.sh
+++ b/hack/static.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-LIBGIT2_URL="${LIBGIT2_URL:-https://github.com/libgit2/libgit2/archive/refs/tags/v1.3.1.tar.gz}"
+LIBGIT2_URL="${LIBGIT2_URL:-https://github.com/libgit2/libgit2/archive/refs/tags/v1.3.2.tar.gz}"
 OPENSSL_URL="${OPENSSL_URL:-https://github.com/openssl/openssl/archive/refs/tags/openssl-3.0.2.tar.gz}"
 LIBSSH2_URL="${LIBSSH2_URL:-https://github.com/libssh2/libssh2/archive/refs/tags/libssh2-1.10.0.tar.gz}"
 


### PR DESCRIPTION
The new version is mostly a security release, with the changes below:
- This provides compatibility with git's changes to address CVE 2022-29187. As a follow up to CVE 2022-24765, now not only is the working directory of a non-bare repository examined for its ownership, but the .git directory and the .git file (if present) are also examined for their ownership.

- A fix for compatibility with git's (new) behavior for CVE 2022-24765 allows users on POSIX systems to access a git repository that is owned by them when they are running in sudo.

- A fix for further compatibility with git's (existing) behavior for CVE 2022-24765 allows users on Windows to access a git repository that is owned by the Administrator when running with escalated privileges (using runas Administrator).

- The bundled zlib is updated to v1.2.12, as prior versions had memory corruption bugs. It is not known that there is a security vulnerability in libgit2 based on these bugs, but we are updating to be cautious.

Extract from upstream release: https://github.com/libgit2/libgit2/releases/tag/v1.3.2
