### PR TITLE
Remove `ALLOW_THREADLESS_LIBGIT2`

### DIFF
--- a/Dockerfile.test-libgit2-only
+++ b/Dockerfile.test-libgit2-only
@@ -129,6 +129,5 @@ COPY --from=build \
     /root/smoketest/static-test-runner .
 
 ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
-ENV ALLOW_THREADLESS_LIBGIT2=true
 
 RUN /root/smoketest/static-test-runner

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ export LIBRARY_PATH=$(LIBGIT2_LIB_PATH)
 export PKG_CONFIG_PATH=$(LIBGIT2_LIB_PATH)/pkgconfig
 export CGO_LDFLAGS=$(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --libs --static --cflags libgit2)
 export CGO_CFLAGS=-I$(LIBGIT2_PATH)/include
-export ALLOW_THREADLESS_LIBGIT2=true
 
 GO_STATIC_FLAGS=-tags 'netgo,osusergo,static_build'
 


### PR DESCRIPTION
This environment variable is to be used in combination with the upstream changes that are is yet to be merged. Until they are merged, there is no point in having such vars here.

Follow-up from https://github.com/fluxcd/golang-with-libgit2/pull/37#discussion_r934670150.