### PR TITLE
Build with Go 1.19

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -107,7 +107,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
       - name: Setup Cosign
         uses: sigstore/cosign-installer@main
       - name: Setup Syft

--- a/Dockerfile.libgit2-only
+++ b/Dockerfile.libgit2-only
@@ -1,7 +1,7 @@
 # This Dockerfile builds and packages libgit2 only (not linked with openssl and libssh2)
 
 ARG BASE_VARIANT=alpine
-ARG GO_VERSION=1.18
+ARG GO_VERSION=1.19
 ARG XX_VERSION=1.1.2
 
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx

--- a/Dockerfile.test-libgit2-only
+++ b/Dockerfile.test-libgit2-only
@@ -1,7 +1,7 @@
 # This Dockerfile builds and packages libgit2 only (not linked with openssl and libssh2); and tests it against git2go.
 
 ARG BASE_VARIANT=alpine
-ARG GO_VERSION=1.18
+ARG GO_VERSION=1.19
 ARG XX_VERSION=1.1.2
 
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx

--- a/tests/smoketest/go.mod
+++ b/tests/smoketest/go.mod
@@ -1,6 +1,6 @@
 module github.com/fluxcd/golang-with-libgit2/tests/sample
 
-go 1.18
+go 1.19
 
 // A temporary fork of git2go was created to enable use
 // of libgit2 without thread support to fix:


### PR DESCRIPTION
Update Go to 1.19 in CI and in base images.