### PR TITLE
Bump libgit2 to 1.5.0

### DIFF
--- a/Dockerfile.libgit2-only
+++ b/Dockerfile.libgit2-only
@@ -15,6 +15,7 @@ RUN apk add --no-cache \
         linux-headers \
         perl \
         cmake \
+        python3-dev \
         pkgconfig \
         gcc \
         musl-dev \

--- a/Dockerfile.test-libgit2-only
+++ b/Dockerfile.test-libgit2-only
@@ -15,6 +15,7 @@ RUN apk add --no-cache \
         linux-headers \
         perl \
         cmake \
+        python3-dev \
         pkgconfig \
         gcc \
         musl-dev \
@@ -105,10 +106,10 @@ COPY --from=libs /usr/local/ /usr/local/
 
 ENV CGO_ENABLED=1
 RUN export LIBRARY_PATH="/usr/local/$(xx-info triple)" && \
-    export PKG_CONFIG_PATH="/usr/local/$(xx-info triple)/lib/pkgconfig" && \
-    export FLAGS="$(pkg-config --static --libs --cflags libgit2)" && \
-    export CGO_LDFLAGS="${FLAGS} -static" && \
-    xx-go build  \
+        export PKG_CONFIG_PATH="/usr/local/$(xx-info triple)/lib/pkgconfig" && \
+        export FLAGS="$(pkg-config --static --libs --cflags libgit2)" && \
+        export CGO_LDFLAGS="${FLAGS} -static" && \
+        xx-go build  \
         -ldflags "-s -w" \
         -tags 'netgo,osusergo,static_build' \
         -o static-test-runner -trimpath main.go
@@ -126,7 +127,7 @@ RUN apk add git
 
 WORKDIR /root/smoketest
 COPY --from=build \
-    /root/smoketest/static-test-runner .
+        /root/smoketest/static-test-runner .
 
 ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 

--- a/hack/static.sh
+++ b/hack/static.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-LIBGIT2_URL="${LIBGIT2_URL:-https://github.com/libgit2/libgit2/archive/refs/tags/v1.3.2.tar.gz}"
+LIBGIT2_URL="${LIBGIT2_URL:-https://github.com/libgit2/libgit2/archive/refs/tags/v1.5.0.tar.gz}"
 
 TARGET_DIR="${TARGET_DIR:-/usr/local/$(xx-info triple)}"
 BUILD_ROOT_DIR="${BUILD_ROOT_DIR:-/build}"
@@ -55,11 +55,13 @@ function build_libgit2_only(){
     -DCMAKE_C_FLAGS=-fPIC \
     -DUSE_SSH:BOOL=OFF \
     -DHAVE_LIBSSH2_MEMORY_CREDENTIALS:BOOL=OFF \
-    -DDEPRECATE_HARD:BOOL=ON \
+    -DDEPRECATE_HARD:BOOL=OFF \
     -DUSE_BUNDLED_ZLIB:BOOL=ON \
     -DUSE_HTTPS:STRING:BOOL=OFF \
     -DREGEX_BACKEND:STRING=builtin \
     -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
+    -DBUILD_TESTS:BOOL=OFF \
+    -DPYTHON_EXECUTABLE="/usr/bin/python3" \
     ..
 
     cmake --build . --target install

--- a/tests/smoketest/go.mod
+++ b/tests/smoketest/go.mod
@@ -2,21 +2,13 @@ module github.com/fluxcd/golang-with-libgit2/tests/sample
 
 go 1.19
 
-// A temporary fork of git2go was created to enable use
-// of libgit2 without thread support to fix:
-// fluxcd/image-automation-controller/#339.
-//
-// This can be removed once libgit2/git2go#918 is merged.
-//
-// The fork automatically releases new patches based on upstream:
-// https://github.com/pjbgf/git2go/commit/d72e39cdc20f7fe014ba73072b01ba7b569e9253
-replace github.com/libgit2/git2go/v33 => github.com/pjbgf/git2go/v33 v33.0.9-nothread-check
+replace github.com/libgit2/git2go/v34 => github.com/fluxcd/git2go/v34 v34.0.0
 
 require (
 	github.com/fluxcd/pkg/gittestserver v0.5.2
 	github.com/fluxcd/pkg/ssh v0.3.2
 	github.com/fluxcd/source-controller v0.24.4
-	github.com/libgit2/git2go/v33 v33.0.9
+	github.com/libgit2/git2go/v34 v34.0.0
 	golang.org/x/crypto v0.0.0-20220427172511-eb4f295cb31f
 )
 

--- a/tests/smoketest/go.sum
+++ b/tests/smoketest/go.sum
@@ -32,6 +32,8 @@ github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/fluxcd/git2go/v34 v34.0.0 h1:08PEpdbsLO4sUTvFKuxmt6xBowaqObro9veChBWFwa8=
+github.com/fluxcd/git2go/v34 v34.0.0/go.mod h1:blVco2jDAw6YTXkErMMqzHLcAjKkwF0aWIRHBqiJkZ0=
 github.com/fluxcd/pkg/gittestserver v0.5.2 h1:Tt2g1C2b3DB4OM7ZX9hsj6scPdpnkl0xjH85ZkNvIzA=
 github.com/fluxcd/pkg/gittestserver v0.5.2/go.mod h1:QNv2arrHGReWIev8rp3Stg1JMq+xqT/lomSFZ2KfMBI=
 github.com/fluxcd/pkg/ssh v0.3.2 h1:HZlDF6Qu4yplsU4Tisv6hxsRIbIOwwr7rKus8/Q/Dn0=
@@ -148,8 +150,6 @@ github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGV
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.19.0 h1:4ieX6qQjPP/BfC3mpsAtIGGlxTWPeA3Inl/7DtXw1tw=
-github.com/pjbgf/git2go/v33 v33.0.9-nothread-check h1:gSK7FaLECIM3VSuBOAsVZQtWd+51iTB5lv9RyxhOYMk=
-github.com/pjbgf/git2go/v33 v33.0.9-nothread-check/go.mod h1:KdpqkU+6+++4oHna/MIOgx4GCQ92IPCdpVRMRI80J+4=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/tests/smoketest/main.go
+++ b/tests/smoketest/main.go
@@ -18,9 +18,7 @@ import (
 	"hash"
 	"time"
 
-	// git2go must be aligned with libgit2 version:
-	// https://github.com/libgit2/git2go#which-go-version-to-use
-	git2go "github.com/libgit2/git2go/v33"
+	git2go "github.com/libgit2/git2go/v34"
 
 	"github.com/fluxcd/pkg/gittestserver"
 	"github.com/fluxcd/pkg/ssh"


### PR DESCRIPTION
`DEPRECATE_HARD` has been disabled to allow for the func `git_indexer_hash`
to be used, as git2go hasn't moved on from it yet.

This change redirect the git2go dependency to Flux's git2go fork.
Note that upstream has a v35 Git tag that points to the v34 Go module,
which currently does not work. Instead Flux's fork has a v34 Git tag.

More information: https://github.com/libgit2/git2go/issues/938